### PR TITLE
Feat(LuaEngine/ItemTemplateMethods): Update GetName for support player locale

### DIFF
--- a/src/LuaEngine/methods/ItemTemplateMethods.h
+++ b/src/LuaEngine/methods/ItemTemplateMethods.h
@@ -53,7 +53,7 @@ namespace LuaItemTemplate
      */
     int GetName(lua_State* L, ItemTemplate* itemTemplate)
     {
-        uint32 loc_idx = Forge::CHECKVAL<uint32>(L, 2, LocaleConstant::LOCALE_enUS);
+        uint32 loc_idx = Eluna::CHECKVAL<uint32>(L, 2, LocaleConstant::LOCALE_enUS);
 
         const ItemLocale* itemLocale = eObjectMgr->GetItemLocale(itemTemplate->ItemId);
         std::string name = itemTemplate->Name1;
@@ -61,7 +61,7 @@ namespace LuaItemTemplate
         if (itemLocale && !itemLocale->Name[loc_idx].empty())
             name = itemLocale->Name[loc_idx];
 
-        Forge::Push(L, name);
+        Eluna::Push(L, name);
         return 1;
     }
 

--- a/src/LuaEngine/methods/ItemTemplateMethods.h
+++ b/src/LuaEngine/methods/ItemTemplateMethods.h
@@ -45,13 +45,23 @@ namespace LuaItemTemplate
     }
 
     /**
-     * Returns the [ItemTemplate]'s name.
+     * Returns the [ItemTemplate]'s name in the [Player]'s locale.
      *
+     * @param [LocaleConstant] locale = DEFAULT_LOCALE : locale to return the [ItemTemplate] name in (it's optional default: LOCALE_enUS)
+     * 
      * @return string name
      */
     int GetName(lua_State* L, ItemTemplate* itemTemplate)
     {
-        Eluna::Push(L, itemTemplate->Name1);
+        uint32 loc_idx = Forge::CHECKVAL<uint32>(L, 2, LocaleConstant::LOCALE_enUS);
+
+        const ItemLocale* itemLocale = eObjectMgr->GetItemLocale(itemTemplate->ItemId);
+        std::string name = itemTemplate->Name1;
+
+        if (itemLocale && !itemLocale->Name[loc_idx].empty())
+            name = itemLocale->Name[loc_idx];
+
+        Forge::Push(L, name);
         return 1;
     }
 


### PR DESCRIPTION
## 📝 Description

This pull request introduces one modified methods in `mod-eluna` for `ItemTemplate`:

- `SetRespawnDelay`

## 🆕 Modified Methods Overview

### 1. `GetName()`
Get the ItemTemplate name in the Player locale.

#### Example
```lua
itemtemplate:GetName() -- Default use LOCALE_enUS
itemtemplate:GetName(1) -- Use koKR player locale item name
```