### PR TITLE
fix: Correctly describe possible sizes of packed GUIDs

### DIFF
--- a/src/LuaEngine/methods/WorldPacketMethods.h
+++ b/src/LuaEngine/methods/WorldPacketMethods.h
@@ -174,7 +174,8 @@ namespace LuaPacket
     }
 
     /**
-     * Reads and returns an unsigned 64-bit integer value from the [WorldPacket].
+     * Reads a packed GUID from the [WorldPacket] and returns it as a full 64-bit integer.
+     * The packed data size varies (2-9 bytes), but always unpacks to a complete 64-bit GUID.
      *
      * @return uint64 value : value returned as string
      */


### PR DESCRIPTION
The current docs refer to the size of the packedGUID being read as 64 bits. That is only true after unpacking it; the initial size can range from 2 to 9 bytes. This is of importance to ensure that users understand the size variation of packets that contain packed GUIDs and don't read past the byte buffer length.