### PR TITLE
feat(LuaEngine/Packed GUIDs) Add support for writing packed GUIDs and reading packed GUID size

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -1204,6 +1204,7 @@ ElunaRegister<WorldPacket> PacketMethods[] =
     { "WriteLong", &LuaPacket::WriteLong },
     { "WriteULong", &LuaPacket::WriteULong },
     { "WriteGUID", &LuaPacket::WriteGUID },
+    { "WritePackedGUID", &LuaPacket::WritePackedGUID },
     { "WriteString", &LuaPacket::WriteString },
     { "WriteFloat", &LuaPacket::WriteFloat },
     { "WriteDouble", &LuaPacket::WriteDouble },

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -1180,7 +1180,6 @@ ElunaRegister<WorldPacket> PacketMethods[] =
     // Getters
     { "GetOpcode", &LuaPacket::GetOpcode },
     { "GetSize", &LuaPacket::GetSize },
-    { "GetPackedGUIDSize", &LuaPacket::GetPackedGUIDSize },
 
     // Setters
     { "SetOpcode", &LuaPacket::SetOpcode },

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -113,6 +113,7 @@ luaL_Reg GlobalMethods[] =
     { "GetGUIDLow", &LuaGlobalFunctions::GetGUIDLow },
     { "GetGUIDType", &LuaGlobalFunctions::GetGUIDType },
     { "GetGUIDEntry", &LuaGlobalFunctions::GetGUIDEntry },
+    { "GetPackedGUIDSize", &LuaGlobalFunctions::GetPackedGUIDSize },
     { "GetAreaName", &LuaGlobalFunctions::GetAreaName },
     { "GetOwnerHalaa", &LuaGlobalFunctions::GetOwnerHalaa },
     { "bit_not", &LuaGlobalFunctions::bit_not },
@@ -1179,6 +1180,7 @@ ElunaRegister<WorldPacket> PacketMethods[] =
     // Getters
     { "GetOpcode", &LuaPacket::GetOpcode },
     { "GetSize", &LuaPacket::GetSize },
+    { "GetPackedGUIDSize", &LuaPacket::GetPackedGUIDSize },
 
     // Setters
     { "SetOpcode", &LuaPacket::SetOpcode },

--- a/src/LuaEngine/methods/GlobalMethods.h
+++ b/src/LuaEngine/methods/GlobalMethods.h
@@ -469,6 +469,20 @@ namespace LuaGlobalFunctions
     }
 
     /**
+     * Returns the byte size of the ObjectGuid when packed.
+     *
+     * @param ObjectGuid guid : the ObjectGuid to get packed size for
+     * @return number : size in bytes (2-9)
+     */
+    int GetPackedGUIDSize(lua_State* L)
+    {
+        ObjectGuid guid = Eluna::CHECKVAL<ObjectGuid>(L, 1);
+        PackedGuid packedGuid(guid);
+        Eluna::Push(L, packedGuid.size());
+        return 1;
+    }
+
+    /**
      * Returns the area or zone's name.
      *
      *     enum LocaleConstant

--- a/src/LuaEngine/methods/GlobalMethods.h
+++ b/src/LuaEngine/methods/GlobalMethods.h
@@ -478,7 +478,7 @@ namespace LuaGlobalFunctions
     {
         ObjectGuid guid = Eluna::CHECKVAL<ObjectGuid>(L, 1);
         PackedGuid packedGuid(guid);
-        Eluna::Push(L, packedGuid.size());
+        Eluna::Push(L, static_cast<int>(packedGuid.size()));
         return 1;
     }
 

--- a/src/LuaEngine/methods/GlobalMethods.h
+++ b/src/LuaEngine/methods/GlobalMethods.h
@@ -469,10 +469,10 @@ namespace LuaGlobalFunctions
     }
 
     /**
-     * Returns the byte size of the ObjectGuid when packed.
+     * Returns the byte size in bytes (2-9) of the ObjectGuid when packed.
      *
      * @param ObjectGuid guid : the ObjectGuid to get packed size for
-     * @return number : size in bytes (2-9)
+     * @return number size
      */
     int GetPackedGUIDSize(lua_State* L)
     {

--- a/src/LuaEngine/methods/WorldPacketMethods.h
+++ b/src/LuaEngine/methods/WorldPacketMethods.h
@@ -212,6 +212,19 @@ namespace LuaPacket
     }
 
     /**
+     * Writes an ObjectGuid as packed GUID format to the [WorldPacket].
+     *
+     * @param ObjectGuid value : the ObjectGuid to be packed to the [WorldPacket]
+     */
+    int WritePackedGUID(lua_State* L, WorldPacket* packet)
+    {
+        ObjectGuid guid = Eluna::CHECKVAL<ObjectGuid>(L, 2);
+        PackedGuid packedGuid(guid);
+        (*packet) << packedGuid;
+        return 0;
+    }
+
+    /**
      * Writes a string to the [WorldPacket].
      *
      * @param string value : the string to be written to the [WorldPacket]


### PR DESCRIPTION
This lets users create and manipulate packets that involve packed GUIDs as opposed to full GUIDs directly.

Example implementation, where the client needs to receive a packed GUID:

```
local function OnCommand_TestPackedGUID(event, player, command)
    if not (command == "testPackedGUID") then return end

    local SMSG_FORCE_MOVE_ROOT = 0x0E8

    local playerGuid = player:GetGUID()
    local packedSize = GetPackedGUIDSize(playerGuid)
    local PACKET_SIZE = math.min(packedSize + 4, 13)  -- Ulong is 4 bytes, packed GUID is up to 9 bytes

    local packet = CreatePacket(SMSG_FORCE_MOVE_ROOT, PACKET_SIZE)
    packet:WritePackedGUID(playerGuid)
    packet:WriteULong(2)

    player:SendPacket(packet)
    player:SendBroadcastMessage("You have been rooted by a packet and your packedGUID!")
    return false
end

RegisterPlayerEvent(42, OnCommand_TestPackedGUID)
```