### PR TITLE
fix: Update nodeId to a uint32 in GetKnownTaxiNodes

### DIFF
--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -1683,7 +1683,7 @@ namespace LuaPlayer
             {
                 if (mask & (1 << bit))
                 {
-                    uint8 nodeId = (i * 32) + bit + 1;
+                    uint32 nodeId = (i * 32) + bit + 1;
                     lua_pushinteger(L, nodeId);
                     lua_rawseti(L, -2, lua_rawlen(L, -2) + 1);
                 }


### PR DESCRIPTION
Commit bcfe631307cda63514492366f659549ecf050854 added a new GetKnownTaxiNodes method.  With further testing, nodeId should be a uint32 (not uint8) so nodes >= 256 can't overflow if the mask grows.