### PR TITLE
fix(LuaEngine/UnitMethods): rename HandleStatModifier to match a PR#23346

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -416,7 +416,7 @@ ALERegister<Unit> UnitMethods[] =
     { "IsOnVehicle", &LuaUnit::IsOnVehicle },
 
     // Other
-    { "HandleStatModifier", &LuaUnit::HandleStatModifier },
+    { "HandleStatFlatModifier", &LuaUnit::HandleStatFlatModifier },
     { "AddAura", &LuaUnit::AddAura },
     { "RemoveAura", &LuaUnit::RemoveAura },
     { "RemoveAllAuras", &LuaUnit::RemoveAllAuras },

--- a/src/LuaEngine/methods/UnitMethods.h
+++ b/src/LuaEngine/methods/UnitMethods.h
@@ -73,7 +73,7 @@ namespace LuaUnit
      * @param bool apply = false : Whether the modifier should be applied or removed
      * @return bool : Whether the stat modification was successful
      */
-    int HandleStatModifier(lua_State* L, Unit* unit)
+    int HandleStatFlatModifier(lua_State* L, Unit* unit)
     {
         int32 stat = ALE::CHECKVAL<int32>(L, 2);
         int8  type = ALE::CHECKVAL<int8>(L, 3);
@@ -81,7 +81,7 @@ namespace LuaUnit
         float value = ALE::CHECKVAL<float>(L, 4);
         bool apply = ALE::CHECKVAL<bool>(L, 5, false);
 
-        ALE::Push(L, unit->HandleStatModifier(UnitMods(UNIT_MOD_STAT_START + stat), (UnitModifierType)type, value, apply));
+        ALE::Push(L, unit->HandleStatFlatModifier(UnitMods(UNIT_MOD_STAT_START + stat), (UnitModifierFlatType)type, value, apply));
         return 1;
     }
 


### PR DESCRIPTION
HandleStatModifier is split into Flat and Pct with https://github.com/azerothcore/azerothcore-wotlk/pull/23346

I intentionally left the new ApplyStatPctModifier as that should only be touched by the AuraEffects.