### PR TITLE
fix(lua-engine): update function call to match core API

### DIFF
--- a/src/LuaEngine/methods/UnitMethods.h
+++ b/src/LuaEngine/methods/UnitMethods.h
@@ -81,7 +81,7 @@ namespace LuaUnit
         float value = ALE::CHECKVAL<float>(L, 4);
         bool apply = ALE::CHECKVAL<bool>(L, 5, false);
 
-        ALE::Push(L, unit->HandleStatFlatModifier(UnitMods(UNIT_MOD_STAT_START + stat), (UnitModifierFlatType)type, value, apply));
+        ALE::Push(L, unit->HandleStatModifier(UnitMods(UNIT_MOD_STAT_START + stat), (UnitModifierType)type, value, apply));
         return 1;
     }
 


### PR DESCRIPTION

Updated the incompatible function call in `UnitMethods.h` to fix compilation errors.

- **Change:** Replaced `HandleStatFlatModifier` with `HandleStatModifier`.
- **Reason:** The original function and type (`UnitModifierFlatType`) do not exist in the current AzerothCore codebase, causing a fatal compilation error.
- **Effect:** The module `mod-ale` is now compatible with the core and compiles successfully.