### PR TITLE
fix(LuaEngine): Register Loot type to fix GetLoot() method

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -1954,6 +1954,9 @@ void RegisterFunctions(ALE* E)
 
     ALETemplate<CreatureTemplate>::Register(E, "CreatureTemplate");
 
+    ALETemplate<Loot>::Register(E, "Loot");
+    ALETemplate<Loot>::SetMethods(E, LootMethods);
+
     ALETemplate<long long>::Register(E, "long long", true);
 
     ALETemplate<unsigned long long>::Register(E, "unsigned long long", true);


### PR DESCRIPTION
Fixed the issue where calling GetLoot() on Creature in Lua scripts would fail with error: "calling 'GetLoot' on bad self (Creature expected, got pointer to nonexisting (invalidated) object (userdata)."

The problem was that while GetLoot() method was registered for Creature, the Loot type itself was not registered in the Lua engine, causing the returned Loot object to be unrecognized by Lua.

Added Loot type registration to properly expose Loot objects to Lua:
- ALETemplate<Loot>::Register(E, "Loot")
- ALETemplate<Loot>::SetMethods(E, LootMethods)