### PR TITLE
fix(Core): Update packet hook signatures to const WorldPacket&

### DIFF
--- a/src/ALE_SC.cpp
+++ b/src/ALE_SC.cpp
@@ -976,7 +976,7 @@ public:
         SERVERHOOK_CAN_PACKET_RECEIVE
     }) { }
 
-    bool CanPacketSend(WorldSession* session, WorldPacket& packet) override
+    bool CanPacketSend(WorldSession* session, WorldPacket const& packet) override
     {
         if (!sALE->OnPacketSend(session, packet))
             return false;
@@ -984,7 +984,7 @@ public:
         return true;
     }
 
-    bool CanPacketReceive(WorldSession* session, WorldPacket& packet) override
+    bool CanPacketReceive(WorldSession* session, WorldPacket const& packet) override
     {
         if (!sALE->OnPacketReceive(session, packet))
             return false;

--- a/src/LuaEngine/LuaEngine.h
+++ b/src/LuaEngine/LuaEngine.h
@@ -451,9 +451,9 @@ public:
     bool OnPacketSend(WorldSession* session, const WorldPacket& packet);
     void OnPacketSendAny(Player* player, const WorldPacket& packet, bool& result);
     void OnPacketSendOne(Player* player, const WorldPacket& packet, bool& result);
-    bool OnPacketReceive(WorldSession* session, WorldPacket& packet);
-    void OnPacketReceiveAny(Player* player, WorldPacket& packet, bool& result);
-    void OnPacketReceiveOne(Player* player, WorldPacket& packet, bool& result);
+    bool OnPacketReceive(WorldSession* session, WorldPacket const& packet);
+    void OnPacketReceiveAny(Player* player, WorldPacket const& packet, bool& result);
+    void OnPacketReceiveOne(Player* player, WorldPacket const& packet, bool& result);
 
     /* Player */
     void OnPlayerEnterCombat(Player* pPlayer, Unit* pEnemy);

--- a/src/LuaEngine/hooks/PacketHooks.cpp
+++ b/src/LuaEngine/hooks/PacketHooks.cpp
@@ -79,7 +79,7 @@ void ALE::OnPacketSendOne(Player* player, const WorldPacket& packet, bool& resul
     CleanUpStack(2);
 }
 
-bool ALE::OnPacketReceive(WorldSession* session, WorldPacket& packet)
+bool ALE::OnPacketReceive(WorldSession* session, WorldPacket const& packet)
 {
     bool result = true;
     Player* player = NULL;
@@ -90,7 +90,7 @@ bool ALE::OnPacketReceive(WorldSession* session, WorldPacket& packet)
     return result;
 }
 
-void ALE::OnPacketReceiveAny(Player* player, WorldPacket& packet, bool& result)
+void ALE::OnPacketReceiveAny(Player* player, WorldPacket const& packet, bool& result)
 {
     START_HOOK_SERVER(SERVER_EVENT_ON_PACKET_RECEIVE);
     Push(new WorldPacket(packet));
@@ -99,22 +99,18 @@ void ALE::OnPacketReceiveAny(Player* player, WorldPacket& packet, bool& result)
 
     while (n > 0)
     {
-        int r = CallOneFunction(n--, 2, 2);
+        int r = CallOneFunction(n--, 2, 1);
 
         if (lua_isboolean(L, r + 0) && !lua_toboolean(L, r + 0))
             result = false;
 
-        if (lua_isuserdata(L, r + 1))
-            if (WorldPacket* data = CHECKOBJ<WorldPacket>(L, r + 1, false))
-                packet = *data;
-
-        lua_pop(L, 2);
+        lua_pop(L, 1);
     }
 
     CleanUpStack(2);
 }
 
-void ALE::OnPacketReceiveOne(Player* player, WorldPacket& packet, bool& result)
+void ALE::OnPacketReceiveOne(Player* player, WorldPacket const& packet, bool& result)
 {
     START_HOOK_PACKET(PACKET_EVENT_ON_PACKET_RECEIVE, packet.GetOpcode());
     Push(new WorldPacket(packet));
@@ -123,16 +119,12 @@ void ALE::OnPacketReceiveOne(Player* player, WorldPacket& packet, bool& result)
 
     while (n > 0)
     {
-        int r = CallOneFunction(n--, 2, 2);
+        int r = CallOneFunction(n--, 2, 1);
 
         if (lua_isboolean(L, r + 0) && !lua_toboolean(L, r + 0))
             result = false;
 
-        if (lua_isuserdata(L, r + 1))
-            if (WorldPacket* data = CHECKOBJ<WorldPacket>(L, r + 1, false))
-                packet = *data;
-
-        lua_pop(L, 2);
+        lua_pop(L, 1);
     }
 
     CleanUpStack(2);


### PR DESCRIPTION
Adapts to azerothcore/azerothcore-wotlk#25063 which changes `CanPacketSend` and `CanPacketReceive` to take `WorldPacket const&` instead of `WorldPacket&`.

- Update `CanPacketSend` and `CanPacketReceive` override signatures
- Update internal `OnPacketReceive` chain to match new const signature
- Remove packet write-back from Lua receive hooks (core no longer provides mutable packet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)