### PR TITLE
feat(LuaEngine): Add GetInventoryFreeSlots and GetBankFreeSlots to Player class

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -476,6 +476,8 @@ ALERegister<Unit> UnitMethods[] =
 ALERegister<Player> PlayerMethods[] =
 {
     // Getters
+    { "GetInventoryFreeSlots", &LuaPlayer::GetInventoryFreeSlots },
+    { "GetBankFreeSlots", &LuaPlayer::GetBankFreeSlots },
     { "GetSelection", &LuaPlayer::GetSelection },
     { "GetGMRank", &LuaPlayer::GetGMRank },
     { "GetGuildId", &LuaPlayer::GetGuildId },

--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -317,6 +317,71 @@ namespace LuaPlayer
     }
 
     /**
+     * Returns the number of free slots in the [Player]'s inventory (backpack and equipped bags).
+     *
+     * @return uint32 freeSlots
+     */
+    int GetInventoryFreeSlots(lua_State* L, Player* player)
+    {
+        uint32 freeSlots = 0;
+
+        // Backpack (Bolsa principal 0, slots 0 al 18)
+        for (uint8 i = INVENTORY_SLOT_ITEM_START; i < INVENTORY_SLOT_ITEM_END; ++i)
+        {
+            if (!player->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
+                ++freeSlots;
+        }
+
+        // Bolsas equipadas (Slots 19 al 22)
+        for (uint8 i = INVENTORY_SLOT_BAG_START; i < INVENTORY_SLOT_BAG_END; ++i)
+        {
+            if (Bag* bag = player->GetBagByPos(i))
+            {
+                for (uint32 j = 0; j < bag->GetBagSize(); ++j)
+                {
+                    if (!player->GetItemByPos(i, j))
+                        ++freeSlots;
+                }
+            }
+        }
+
+        ALE::Push(L, freeSlots);
+        return 1;
+    }
+
+    /**
+     * Returns the number of free slots in the [Player]'s bank (main bank and bank bags).
+     *
+     * @return uint32 freeSlots
+     */
+    int GetBankFreeSlots(lua_State* L, Player* player)
+    {
+        uint32 freeSlots = 0;
+
+        for (uint8 i = BANK_SLOT_ITEM_START; i < BANK_SLOT_ITEM_END; ++i)
+        {
+            if (!player->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
+                ++freeSlots;
+        }
+
+        for (uint8 i = BANK_SLOT_BAG_START; i < BANK_SLOT_BAG_END; ++i)
+        {
+            if (Bag* bag = player->GetBagByPos(i))
+            {
+                for (uint32 j = 0; j < bag->GetBagSize(); ++j)
+                {
+                    if (!player->GetItemByPos(i, j))
+                        ++freeSlots;
+                }
+            }
+        }
+
+        ALE::Push(L, freeSlots);
+        return 1;
+    }
+
+
+    /**
      * Returns `true` if the [Player] has a Tank Specialization, `false` otherwise.
      *
      * @return bool HasTankSpec

--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -325,22 +325,14 @@ namespace LuaPlayer
     {
         uint32 freeSlots = 0;
 
-<<<<<<< HEAD
-        // Check backpack slots (INVENTORY_SLOT_ITEM_START to INVENTORY_SLOT_ITEM_END)
-=======
         // Backpack slots in INVENTORY_SLOT_BAG_0 (INVENTORY_SLOT_ITEM_START to INVENTORY_SLOT_ITEM_END)
->>>>>>> 73ccf27a343bf41575cbba03d7e73ff9c19763fc
         for (uint8 i = INVENTORY_SLOT_ITEM_START; i < INVENTORY_SLOT_ITEM_END; ++i)
         {
             if (!player->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
                 ++freeSlots;
         }
 
-<<<<<<< HEAD
         // Check equipped bags slots (INVENTORY_SLOT_BAG_START to INVENTORY_SLOT_BAG_END)
-=======
-        // Equipped bag slots (INVENTORY_SLOT_BAG_START to INVENTORY_SLOT_BAG_END)
->>>>>>> 73ccf27a343bf41575cbba03d7e73ff9c19763fc
         for (uint8 i = INVENTORY_SLOT_BAG_START; i < INVENTORY_SLOT_BAG_END; ++i)
         {
             if (Bag* bag = player->GetBagByPos(i))

--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -325,14 +325,14 @@ namespace LuaPlayer
     {
         uint32 freeSlots = 0;
 
-        // Backpack (Bolsa principal 0, slots 0 al 18)
+        // Backpack slots in INVENTORY_SLOT_BAG_0 (INVENTORY_SLOT_ITEM_START to INVENTORY_SLOT_ITEM_END)
         for (uint8 i = INVENTORY_SLOT_ITEM_START; i < INVENTORY_SLOT_ITEM_END; ++i)
         {
             if (!player->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
                 ++freeSlots;
         }
 
-        // Bolsas equipadas (Slots 19 al 22)
+        // Equipped bag slots (INVENTORY_SLOT_BAG_START to INVENTORY_SLOT_BAG_END)
         for (uint8 i = INVENTORY_SLOT_BAG_START; i < INVENTORY_SLOT_BAG_END; ++i)
         {
             if (Bag* bag = player->GetBagByPos(i))

--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -325,14 +325,14 @@ namespace LuaPlayer
     {
         uint32 freeSlots = 0;
 
-        // Backpack (Bolsa principal 0, slots 0 al 18)
+        // Check backpack slots (INVENTORY_SLOT_ITEM_START to INVENTORY_SLOT_ITEM_END)
         for (uint8 i = INVENTORY_SLOT_ITEM_START; i < INVENTORY_SLOT_ITEM_END; ++i)
         {
             if (!player->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
                 ++freeSlots;
         }
 
-        // Bolsas equipadas (Slots 19 al 22)
+        // Check equipped bags slots (INVENTORY_SLOT_BAG_START to INVENTORY_SLOT_BAG_END)
         for (uint8 i = INVENTORY_SLOT_BAG_START; i < INVENTORY_SLOT_BAG_END; ++i)
         {
             if (Bag* bag = player->GetBagByPos(i))
@@ -358,12 +358,14 @@ namespace LuaPlayer
     {
         uint32 freeSlots = 0;
 
+        // Check main bank slots (BANK_SLOT_ITEM_START to BANK_SLOT_ITEM_END)
         for (uint8 i = BANK_SLOT_ITEM_START; i < BANK_SLOT_ITEM_END; ++i)
         {
             if (!player->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
                 ++freeSlots;
         }
 
+        // Check bank bags slots (BANK_SLOT_BAG_START to BANK_SLOT_BAG_END)
         for (uint8 i = BANK_SLOT_BAG_START; i < BANK_SLOT_BAG_END; ++i)
         {
             if (Bag* bag = player->GetBagByPos(i))


### PR DESCRIPTION
## Description
This PR adds two essential methods to the Player class that were missing in ALE (AzerothCore Lua Engine). Currently, developers have to implement manual loops in Lua to calculate free space across multiple bags, which is inefficient.

## New Methods
- `Player:GetInventoryFreeSlots()`: Returns the total number of free slots in the backpack and all equipped bags.
- `Player:GetBankFreeSlots()`: Returns the total number of free slots in the main bank tab and all bank bags.

## Technical Details
- Implemented in C++ to provide atomic and high-performance results.
- Uses native AzerothCore constants for slot mapping (`INVENTORY_SLOT_ITEM_START`, `BANK_SLOT_BAG_END`, etc.).
- Includes safety checks for empty bag slots to prevent potential crashes.
- Dynamically calculates bag sizes using `bag->GetBagSize()`.

## How to test
```lua
local function OnChat(event, player, msg)
    if (msg == "check_slots") then
        local inv = player:GetInventoryFreeSlots()
        local bank = player:GetBankFreeSlots()
        player:SendBroadcastMessage("Inventory Free Slots: " .. inv)
        player:SendBroadcastMessage("Bank Free Slots: " .. bank)
    end
end
RegisterPlayerEvent(18, OnChat)