### PR TITLE
feat(TransportMethods): Add new Transports class, expose basic transport getters and passenger handling

### DIFF
--- a/src/LuaEngine/ALEIncludes.h
+++ b/src/LuaEngine/ALEIncludes.h
@@ -36,6 +36,7 @@
 #include "SpellInfo.h"
 #include "SpellMgr.h"
 #include "TemporarySummon.h"
+#include "Transport.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
 #include "MapMgr.h"

--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -44,6 +44,7 @@ extern "C"
 #include "SpellInfoMethods.h"
 #include "PetMethods.h"
 #include "LootMethods.h"
+#include "TransportMethods.h"
 
 // DBCStores includes
 #include "GemPropertiesEntryMethods.h"
@@ -258,6 +259,7 @@ ALERegister<WorldObject> WorldObjectMethods[] =
     { "GetExactDistance2d", &LuaWorldObject::GetExactDistance2d },
     { "GetRelativePoint", &LuaWorldObject::GetRelativePoint },
     { "GetAngle", &LuaWorldObject::GetAngle },
+    { "GetTransport", &LuaWorldObject::GetTransport },
 
     // Boolean
     { "IsWithinLoS", &LuaWorldObject::IsWithinLoS },
@@ -1315,6 +1317,7 @@ ALERegister<Map> MapMethods[] =
     { "GetWorldObject", &LuaMap::GetWorldObject },
     { "GetCreatures", &LuaMap::GetCreatures },
     { "GetCreaturesByAreaId", &LuaMap::GetCreaturesByAreaId },
+    { "GetTransports", &LuaMap::GetTransports },
 
 
     // Setters
@@ -1800,6 +1803,22 @@ ALERegister<Loot> LootMethods[] =
     { NULL, NULL }
 };
 
+ALERegister<Transport> TransportMethods[] =
+{
+    // Getters
+    { "GetPassengers", &LuaTransport::GetPassengers },
+
+    // Boolean
+    { "IsMotionTransport", &LuaTransport::IsMotionTransport },
+
+    // Other
+    { "AddPassenger", &LuaTransport::AddPassenger },
+    { "RemovePassenger", &LuaTransport::RemovePassenger },
+    { "EnableMovement", &LuaTransport::EnableMovement },
+
+    { NULL, NULL }
+};
+
 // fix compile error about accessing vehicle destructor
 template<> int ALETemplate<Vehicle>::CollectGarbage(lua_State* L)
 {
@@ -1891,6 +1910,12 @@ void RegisterFunctions(ALE* E)
     ALETemplate<GameObject>::SetMethods(E, WorldObjectMethods);
     ALETemplate<GameObject>::SetMethods(E, GameObjectMethods);
 
+    ALETemplate<Transport>::Register(E, "Transport");
+    ALETemplate<Transport>::SetMethods(E, ObjectMethods);
+    ALETemplate<Transport>::SetMethods(E, WorldObjectMethods);
+    ALETemplate<Transport>::SetMethods(E, GameObjectMethods);
+    ALETemplate<Transport>::SetMethods(E, TransportMethods);
+    
     ALETemplate<Corpse>::Register(E, "Corpse");
     ALETemplate<Corpse>::SetMethods(E, ObjectMethods);
     ALETemplate<Corpse>::SetMethods(E, WorldObjectMethods);

--- a/src/LuaEngine/methods/MapMethods.h
+++ b/src/LuaEngine/methods/MapMethods.h
@@ -389,7 +389,7 @@ namespace LuaMap
     int GetTransports(lua_State* L, Map* map)
     {
         TransportsContainer const& transports = map->GetAllTransports();
-        lua_newtable(L);
+        lua_createtable(L, transports.size(), 0);
         int i = 1;
         for (Transport* transport : transports)
         {

--- a/src/LuaEngine/methods/MapMethods.h
+++ b/src/LuaEngine/methods/MapMethods.h
@@ -379,5 +379,24 @@ namespace LuaMap
         lua_settop(L, tbl);
         return 1;
     }
+
+    
+    /**
+     * Returns a table of all [Transport]s on the [Map]
+     *
+     * @return table transports
+     */
+    int GetTransports(lua_State* L, Map* map)
+    {
+        TransportsContainer const& transports = map->GetAllTransports();
+        lua_newtable(L);
+        int i = 1;
+        for (Transport* transport : transports)
+        {
+            ALE::Push(L, transport);
+            lua_rawseti(L, -2, i++);
+        }
+        return 1;
+    }
 };
 #endif

--- a/src/LuaEngine/methods/TransportMethods.h
+++ b/src/LuaEngine/methods/TransportMethods.h
@@ -1,0 +1,93 @@
+/*
+* Copyright (C) 2010 - 2025 Eluna Lua Engine <https://elunaluaengine.github.io/>
+* This program is free software licensed under GPL version 3
+* Please see the included DOCS/LICENSE.md for more information
+*/
+
+#ifndef TRANSPORTMETHODS_H
+#define TRANSPORTMETHODS_H
+
+#include "Transport.h"
+
+/***
+ * Represents a transport object in the world, such as boats and zeppelins.
+ *
+ * Inherits all methods from: [Object], [WorldObject], [GameObject]
+ */
+namespace LuaTransport
+{
+    /**
+     * Returns a table of all passengers on the [Transport]
+     *
+     * @return table passengers
+     */
+    int GetPassengers(lua_State* L, Transport* transport)
+    {
+        Transport::PassengerSet const& passengers = transport->GetPassengers();
+        lua_newtable(L);
+        int i = 1;
+        for (WorldObject* passenger : passengers)
+        {
+            ALE::Push(L, passenger);
+            lua_rawseti(L, -2, i++);
+        }
+        return 1;
+    }
+
+    /**
+     * Returns 'true' if the [Transport] is a MotionTransport (moving transport such as a boat or zeppelin)
+     *
+     * @return bool isMotionTransport
+     */
+    int IsMotionTransport(lua_State* L, Transport* transport)
+    {
+        ALE::Push(L, dynamic_cast<MotionTransport*>(transport) != nullptr);
+        return 1;
+    }
+
+    /**
+     * Adds a [WorldObject] as a passenger to the [Transport]
+     *
+     * @param [WorldObject] passenger : the object to add as a passenger
+     * @param bool withAll = true : if true, also sets transport movement info on the passenger
+     */
+    int AddPassenger(lua_State* L, Transport* transport)
+    {
+        WorldObject* passenger = ALE::CHECKOBJ<WorldObject>(L, 2);
+        bool withAll = ALE::CHECKVAL<bool>(L, 3, true);
+        transport->AddPassenger(passenger, withAll);
+        return 0;
+    }
+
+    /**
+     * Removes a [WorldObject] passenger from the [Transport]
+     *
+     * @param [WorldObject] passenger : the object to remove
+     * @param bool withAll = true : if true, also clears transport movement info from the passenger
+     */
+    int RemovePassenger(lua_State* L, Transport* transport)
+    {
+        WorldObject* passenger = ALE::CHECKOBJ<WorldObject>(L, 2);
+        bool withAll = ALE::CHECKVAL<bool>(L, 3, true);
+        transport->RemovePassenger(passenger, withAll);
+        return 0;
+    }
+
+    /**
+     * Enables or disables movement on the [Transport]
+     *
+     * Only works on MotionTransports where canBeStopped is set.
+     *
+     * @param bool enabled : true to enable movement, false to stop
+     */
+    int EnableMovement(lua_State* L, Transport* transport)
+    {
+        bool enabled = ALE::CHECKVAL<bool>(L, 2);
+        MotionTransport* mt = dynamic_cast<MotionTransport*>(transport);
+        if (mt)
+            mt->EnableMovement(enabled);
+        return 0;
+    }
+}
+
+#endif

--- a/src/LuaEngine/methods/TransportMethods.h
+++ b/src/LuaEngine/methods/TransportMethods.h
@@ -24,7 +24,7 @@ namespace LuaTransport
     int GetPassengers(lua_State* L, Transport* transport)
     {
         Transport::PassengerSet const& passengers = transport->GetPassengers();
-        lua_newtable(L);
+        lua_createtable(L, static_cast<int>(passengers.size()), 0);
         int i = 1;
         for (WorldObject* passenger : passengers)
         {

--- a/src/LuaEngine/methods/WorldObjectMethods.h
+++ b/src/LuaEngine/methods/WorldObjectMethods.h
@@ -611,7 +611,7 @@ namespace LuaWorldObject
 
         return 1;
     }
-    
+
     /**
      * Returns the transport the [WorldObject] is on, or nil if not on a transport
      *

--- a/src/LuaEngine/methods/WorldObjectMethods.h
+++ b/src/LuaEngine/methods/WorldObjectMethods.h
@@ -611,6 +611,17 @@ namespace LuaWorldObject
 
         return 1;
     }
+    
+    /**
+     * Returns the transport the [WorldObject] is on, or nil if not on a transport
+     *
+     * @return [Transport] transport
+     */
+    int GetTransport(lua_State* L, WorldObject* obj)
+    {
+        ALE::Push(L, static_cast<Transport*>(obj->GetTransport()));
+        return 1;
+    }
 
     /**
      * Sends a [WorldPacket] to [Player]s in sight of the [WorldObject].


### PR DESCRIPTION
These mod-ale additions allow interacting and assigning/removing passengers to transports through Lua. I use it to path NPCs from solid ground to transports, and to better handle playerbots' vehicle assignments, for example.

Re https://github.com/azerothcore/mod-ale/pull/370 - apparently renaming branches closes PRs