### PR TITLE
fix(LuaEngine): Preallocate Lua stack size in PushRefsFor to prevent reallocation during push loop

### DIFF
--- a/src/LuaEngine/BindingMap.h
+++ b/src/LuaEngine/BindingMap.h
@@ -191,6 +191,7 @@ public:
             return;
 
         BindingList& list = result->second;
+        lua_checkstack(L, list.size());
         for (auto i = list.begin(); i != list.end();)
         {
             std::unique_ptr<Binding>& binding = (*i);

--- a/src/LuaEngine/BindingMap.h
+++ b/src/LuaEngine/BindingMap.h
@@ -44,7 +44,7 @@ private:
         { }
 
         ~Binding()
-        {luaL_checkstack
+        {
             luaL_unref(L, LUA_REGISTRYINDEX, functionReference);
         }
     };

--- a/src/LuaEngine/BindingMap.h
+++ b/src/LuaEngine/BindingMap.h
@@ -44,7 +44,7 @@ private:
         { }
 
         ~Binding()
-        {
+        {luaL_checkstack
             luaL_unref(L, LUA_REGISTRYINDEX, functionReference);
         }
     };
@@ -191,7 +191,7 @@ public:
             return;
 
         BindingList& list = result->second;
-        lua_checkstack(L, list.size());
+        luaL_checkstack(L, static_cast<int>(list.size()), "not enough stack space to push function bindings");
         for (auto i = list.begin(); i != list.end();)
         {
             std::unique_ptr<Binding>& binding = (*i);


### PR DESCRIPTION
I recently ran into a problem where I ended up having so many hooks (up to 50) and functions (some 100) called on player commands that I kept getting random crashes and stack corruptions. After some troubleshooting, I found out that when the Lua stack runs out of allocated space during `PushRefsFor`, Lua triggers `luaD_reallocstack` mid-loop, moving the stack to a new memory location. This invalidates raw pointers (`cl`, `base`, `k`, `ra`) held by any `luaV_execute` frame on the C stack, causing a crash.

For example, this script on a clean project crashes on reaching `reload conf`:

```lua
local function OnCommand(event, player, command)
    if command == "test" then
        return false
    end
end
for i = 1, 500 do
    RegisterPlayerEvent(42, OnCommand)
end
CreateLuaEvent(function()
    RunCommand("reload conf")
end, 1000)
```

Whereas with the fix, 500 loops works correctly and I can even increase it to 50 000 without any stack corruption:

```lua
local function OnCommand(event, player, command)
    if command == "test" then
        return false
    end
end
for i = 1, 50000 do
    RegisterPlayerEvent(42, OnCommand)
end
CreateLuaEvent(function()
    RunCommand("reload conf")
end, 1000)
```

The fix is a single `lua_checkstack(L, list.size())` call before the push loop in `PushRefsFor`, preallocating enough stack space for all function refs upfront so no reallocation occurs mid-loop. Now, the stack is safe until it overflows, instead of randomly corrupting.