### PR TITLE
feat(PlayerMethods): Expose GetTalentTreePoints and GetMostPointsTalentTree

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -564,6 +564,8 @@ ALERegister<Player> PlayerMethods[] =
     { "GetLastPetNumber", &LuaPlayer::GetLastPetNumber },
     { "GetLastPetSpell", &LuaPlayer::GetLastPetSpell },
     { "GetQuestSlotQuestId", &LuaPlayer::GetQuestSlotQuestId },
+    { "GetTalentTreePoints", &LuaPlayer::GetTalentTreePoints },
+    { "GetMostPointsTalentTree", &LuaPlayer::GetMostPointsTalentTree },
 
     // Setters
     { "SetTemporaryUnsummonedPetNumber", &LuaPlayer::SetTemporaryUnsummonedPetNumber },

--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -5136,6 +5136,32 @@ namespace LuaPlayer
     #endif
         return 1;
     }
+    
+    /**
+     * Returns the [Player]s spent talent points in each talent tree for the active spec
+     *
+     * @return uint8 tree1, uint8 tree2, uint8 tree3
+     */
+    int GetTalentTreePoints(lua_State* L, Player* player)
+    {
+        uint8 specPoints[3] = {0, 0, 0};
+        player->GetTalentTreePoints(specPoints);
+        ALE::Push(L, specPoints[0]);
+        ALE::Push(L, specPoints[1]);
+        ALE::Push(L, specPoints[2]);
+        return 3;
+    }
+
+    /**
+     * Returns the index of the talent tree the [Player] has spent the most points in for the active spec
+     *
+     * @return uint8 treeIndex
+     */
+    int GetMostPointsTalentTree(lua_State* L, Player* player)
+    {
+        ALE::Push(L, player->GetMostPointsTalentTree());
+        return 1;
+    }
 };
 #endif
 


### PR DESCRIPTION
Re https://github.com/azerothcore/mod-ale/issues/380

Tested through

```
local function OnCommand(event, player, command)
    if command == "testtalenttree" then

        local t1, t2, t3 = player:GetTalentTreePoints()
        local dominant = player:GetMostPointsTalentTree()
        
        player:SendBroadcastMessage("Player talent info: "..player:GetName()..". Class: "..player:GetClass())
        player:SendBroadcastMessage("Tree 1: " .. t1 .. " | Tree 2: " .. t2 .. " | Tree 3: " .. t3)
        player:SendBroadcastMessage("Dominant tree index: " .. dominant)

        return false
    end
end

RegisterPlayerEvent(42, OnCommand)
```

<img width="350" height="558" alt="image" src="https://github.com/user-attachments/assets/cb1de3a8-8e46-4f50-8e4c-80d8d0473c79" />
