### PR TITLE
fix(PlayerMethods): SendListInventory not respecting vendorId override

### DIFF
--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -2390,6 +2390,7 @@ namespace LuaPlayer
      * Sends a vendor window to the [Player] from the [WorldObject] specified.
      *
      * @param [WorldObject] sender
+     * @param uint32 vendorId = 0 : optional entry ID to use for the vendor item list, overriding the sender's default inventory
      */
     int SendListInventory(lua_State* L, Player* player)
     {

--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -2396,7 +2396,19 @@ namespace LuaPlayer
         WorldObject* obj = ALE::CHECKOBJ<WorldObject>(L, 2);
         uint32 vendorId = ALE::CHECKVAL<uint32>(L, 3, 0);
 
+        Creature* creature = obj->ToCreature();
+        bool addedVendorFlag = false;
+        if (vendorId && creature && !creature->HasNpcFlag(UNIT_NPC_FLAG_VENDOR))
+        {
+            creature->SetNpcFlag(UNIT_NPC_FLAG_VENDOR);
+            addedVendorFlag = true;
+        }
+
         player->GetSession()->SendListInventory(obj->GET_GUID(), vendorId);
+
+        if (addedVendorFlag)
+            creature->RemoveNpcFlag(UNIT_NPC_FLAG_VENDOR);
+
         return 0;
     }
 


### PR DESCRIPTION
Fixes #383 

When calling `player:SendListInventory(creature, vendorId)` with a creature that doesn't have `UNIT_NPC_FLAG_VENDOR` set, the core's `GetNPCIfCanInteractWith` check would return null, causing the vendor window to silently fail even though a valid vendorId was provided.

The fix will temporarily add the flag to the creature if it is missing and a vendorId override is specified.  The flag is then removed immediately after, leaving the creature's state unchanged.