### PR TITLE
fix(PlayerMethods): corrected SetSkill argument order

### DIFF
--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -1881,7 +1881,7 @@ namespace LuaPlayer
         uint16 currVal = ALE::CHECKVAL<uint16>(L, 4);
         uint16 maxVal = ALE::CHECKVAL<uint16>(L, 5);
 
-        player->SetSkill(id, currVal, maxVal, step);
+        player->SetSkill(id, step, currVal, maxVal);
         return 0;
     }
 


### PR DESCRIPTION
## Summary

Fixes `Player:SetSkill` argument forwarding in ALE.

AzerothCore core expects:
```cpp
// Player.h
void SetSkill(uint16 id, uint16 step, uint16 currVal, uint16 maxVal);

// Player.cpp
void Player::SetSkill(uint16 id, uint16 step, uint16 newVal, uint16 maxVal)
```

ALE was reading the Lua arguments in that order, but forwarding them incorrectly here:
```cpp
uint16 step = ALE::CHECKVAL<uint16>(L, 3);
uint16 currVal = ALE::CHECKVAL<uint16>(L, 4);
uint16 maxVal = ALE::CHECKVAL<uint16>(L, 5);

player->SetSkill(id, currVal, maxVal, step);
```

And according to the documentation, it matches the expectation from the Core.  So this caused Lua calls like this to pass the values into the core as the wrong fields:
```lua
player:SetSkill(skillId, step, currentVal, maxVal)
```

<img width="1252" height="745" alt="image" src="https://github.com/user-attachments/assets/03fdc039-0ee2-45c8-9ff7-455179a1bba1" />

## Fix

- Forward the arguments in the correct order as expected by AzerothCore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected skill updates so the current value, maximum value, and step are now applied in the proper order.
  * This helps ensure skill changes made through Lua behave as expected in-game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->