### PR TITLE
Fix SetGlyph() can remove the old and apply now glyph effect

### DIFF
--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -3561,8 +3561,19 @@ namespace LuaPlayer
         uint32 glyphId = ALE::CHECKVAL<uint32>(L, 2);
         uint32 slotIndex = ALE::CHECKVAL<uint32>(L, 3);
 
+        // Remove the effect of the old glyph if it exists
+        uint32 oldGlyphId = player->GetGlyph(slotIndex);
+        if (oldGlyphId)
+            if (GlyphPropertiesEntry const* oldEntry = sGlyphPropertiesStore.LookupEntry(oldGlyphId))
+                player->RemoveAurasDueToSpell(oldEntry->SpellId);
+
         player->SetGlyph(slotIndex, glyphId, true);
         player->SendTalentsInfoData(false); // Also handles GlyphData
+
+        // Apply the effect of the new glyph if it exists
+        if (glyphId)
+            if (GlyphPropertiesEntry const* glyphEntry = sGlyphPropertiesStore.LookupEntry(glyphId))
+                player->CastSpell(player, glyphEntry->SpellId, TriggerCastFlags(TRIGGERED_FULL_MASK & ~(TRIGGERED_IGNORE_SHAPESHIFT | TRIGGERED_IGNORE_CASTER_AURASTATE)));
 
         return 0;
     }


### PR DESCRIPTION
The original SetGlyph didn't remove old glyph effects and apply new ones. I've fixed it based on the logic in 
void Player::ActivateSpec(uint8 spec) 
If there is more good way, please improve it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replacing a glyph now removes any effects granted by the previously equipped glyph in that slot.
  * Newly equipped glyph effects are applied immediately after the replacement.
  * Glyph and talent UI/state continue to refresh correctly when glyphs change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->