### PR TITLE
feat(PlayerMethods): Expose RepopAtGraveyard

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -744,6 +744,7 @@ ALERegister<Player> PlayerMethods[] =
     { "RemoveItem", &LuaPlayer::RemoveItem },
     { "RemoveLifetimeKills", &LuaPlayer::RemoveLifetimeKills },
     { "ResurrectPlayer", &LuaPlayer::ResurrectPlayer },
+    { "RepopAtGraveyard", &LuaPlayer::RepopAtGraveyard },
     { "EquipItem", &LuaPlayer::EquipItem },
     { "ResetSpellCooldown", &LuaPlayer::ResetSpellCooldown },
     { "ResetTypeCooldowns", &LuaPlayer::ResetTypeCooldowns },

--- a/src/LuaEngine/methods/PlayerMethods.h
+++ b/src/LuaEngine/methods/PlayerMethods.h
@@ -3605,6 +3605,17 @@ namespace LuaPlayer
     }
 
     /**
+     * Teleports the [Player] to the most appropriate graveyard.
+     *
+     * The graveyard is selected using the [Player]'s corpse location.
+     */
+    int RepopAtGraveyard(lua_State* /*L*/, Player* player)
+    {
+        player->RepopAtGraveyard();
+        return 0;
+    }
+
+    /**
      * Adds a new item to the gossip menu shown to the [Player] on next call to [Player:GossipSendMenu].
      *
      * sender and intid are numbers which are passed directly to the gossip selection handler. Internally they are partly used for the database gossip handling.  


### PR DESCRIPTION
Expose RepopAtGraveyard function to lua scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lua scripting support for returning players to the most appropriate graveyard based on their corpse location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->