### PR TITLE
feat: Add new method for gettings all auras

### DIFF
--- a/src/LuaEngine/LuaFunctions.cpp
+++ b/src/LuaEngine/LuaFunctions.cpp
@@ -309,6 +309,8 @@ ALERegister<Unit> UnitMethods[] =
     { "GetRaceAsString", &LuaUnit::GetRaceAsString },
     { "GetClassAsString", &LuaUnit::GetClassAsString },
     { "GetAura", &LuaUnit::GetAura },
+    { "GetAuras", &LuaUnit::GetAuras },
+    { "GetVisibleAuras", &LuaUnit::GetVisibleAuras },
     { "GetFaction", &LuaUnit::GetFaction },
     { "GetCurrentSpell", &LuaUnit::GetCurrentSpell },
     { "GetCreatureType", &LuaUnit::GetCreatureType },
@@ -1089,6 +1091,9 @@ ALERegister<Aura> AuraMethods[] =
     { "GetAuraId", &LuaAura::GetAuraId },
     { "GetStackAmount", &LuaAura::GetStackAmount },
     { "GetOwner", &LuaAura::GetOwner },
+    { "GetCharges", &LuaAura::GetCharges },
+    { "IsPassive", &LuaAura::IsPassive },
+    { "GetSpellInfo", &LuaAura::GetSpellInfo },
 
     // Setters
     { "SetDuration", &LuaAura::SetDuration },

--- a/src/LuaEngine/methods/AuraMethods.h
+++ b/src/LuaEngine/methods/AuraMethods.h
@@ -115,6 +115,39 @@ namespace LuaAura
     }
 
     /**
+     * Returns the number of charges left on the [Aura].
+     *
+     * @return uint32 charges
+     */
+    int GetCharges(lua_State* L, Aura* aura)
+    {
+        ALE::Push(L, aura->GetCharges());
+        return 1;
+    }
+
+    /**
+     * Returns `true` if the [Aura] is passive, `false` otherwise.
+     *
+     * @return bool isPassive
+     */
+    int IsPassive(lua_State* L, Aura* aura)
+    {
+        ALE::Push(L, aura->IsPassive());
+        return 1;
+    }
+
+    /**
+     * Returns the [SpellInfo] of the spell that created the [Aura].
+     *
+     * @return [SpellInfo] spellInfo
+     */
+    int GetSpellInfo(lua_State* L, Aura* aura)
+    {
+        ALE::Push(L, aura->GetSpellInfo());
+        return 1;
+    }
+
+    /**
      * Change the amount of time before the [Aura] expires.
      *
      * @param int32 duration : the new duration of the Aura, in milliseconds

--- a/src/LuaEngine/methods/UnitMethods.h
+++ b/src/LuaEngine/methods/UnitMethods.h
@@ -1103,6 +1103,52 @@ namespace LuaUnit
     }
 
     /**
+     * Returns a table containing all [Aura]s applied on the [Unit].
+     *
+     * @return table auras : table filled with [Aura] objects
+     */
+    int GetAuras(lua_State* L, Unit* unit)
+    {
+        Unit::AuraApplicationMap const& auras = unit->GetAppliedAuras();
+
+        lua_createtable(L, auras.size(), 0);
+        int tbl = lua_gettop(L);
+        uint32 i = 0;
+
+        for (Unit::AuraApplicationMap::const_iterator itr = auras.begin(); itr != auras.end(); ++itr)
+        {
+            ALE::Push(L, itr->second->GetBase());
+            lua_rawseti(L, tbl, ++i);
+        }
+
+        lua_settop(L, tbl);
+        return 1;
+    }
+
+    /**
+     * Returns a table containing the [Aura]s shown on the [Unit]s buff bar, ordered by aura slot.
+     *
+     * @return table auras : table filled with [Aura] objects
+     */
+    int GetVisibleAuras(lua_State* L, Unit* unit)
+    {
+        Unit::VisibleAuraMap const* auras = unit->GetVisibleAuras();
+
+        lua_createtable(L, auras->size(), 0);
+        int tbl = lua_gettop(L);
+        uint32 i = 0;
+
+        for (Unit::VisibleAuraMap::const_iterator itr = auras->begin(); itr != auras->end(); ++itr)
+        {
+            ALE::Push(L, itr->second->GetBase());
+            lua_rawseti(L, tbl, ++i);
+        }
+
+        lua_settop(L, tbl);
+        return 1;
+    }
+
+    /**
      * Returns a table containing friendly [Unit]'s within given range of the [Unit].
      *
      * @param float range = 533.333 : search radius


### PR DESCRIPTION
Adding new Unit methods for gettings GetVisibleAuras& GetAuras

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lua scripts can now retrieve a unit’s applied auras and visible buff-bar auras.
  * Aura data now includes remaining charges, passive status, and associated spell information.
  * Added Lua access to player graveyard respawn behavior.
  * Visible auras are returned in their buff-bar slot order for more predictable processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->