### PR TITLE
fix: Remove InterruptSpell function

### DIFF
--- a/src/LuaEngine/methods/Playerbots/PlayerBotAIMethods.h
+++ b/src/LuaEngine/methods/Playerbots/PlayerBotAIMethods.h
@@ -890,6 +890,15 @@ namespace LuaPlayerBotAI
     }
 
     /**
+     * Interrupts every spell the bot is currently casting and notifies its client.
+     */
+    int InterruptSpell(lua_State* /*L*/, PlayerbotAI* botAI)
+    {
+        botAI->RequestSpellInterrupt();
+        return 0;
+    }
+
+    /**
      * Asks the bot AI to interrupt its current cast on the next update.
      */
     int RequestSpellInterrupt(lua_State* /*L*/, PlayerbotAI* botAI)

--- a/src/LuaEngine/methods/Playerbots/PlayerBotAIMethods.h
+++ b/src/LuaEngine/methods/Playerbots/PlayerBotAIMethods.h
@@ -890,15 +890,6 @@ namespace LuaPlayerBotAI
     }
 
     /**
-     * Interrupts every spell the bot is currently casting and notifies its client.
-     */
-    int InterruptSpell(lua_State* /*L*/, PlayerbotAI* botAI)
-    {
-        botAI->InterruptSpell();
-        return 0;
-    }
-
-    /**
      * Asks the bot AI to interrupt its current cast on the next update.
      */
     int RequestSpellInterrupt(lua_State* /*L*/, PlayerbotAI* botAI)


### PR DESCRIPTION
Removed the InterruptSpell function from PlayerBotAIMethods.h
And fix https://github.com/azerothcore/mod-ale/issues/398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
  - The Lua `InterruptSpell` interface now requests a deferred spell interruption instead of immediately interrupting all spells currently being cast by a bot.
  - Spell interruption may therefore occur after the current processing step rather than instantly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->